### PR TITLE
v2.3.0

### DIFF
--- a/.github/workflows/build, draft release.yml
+++ b/.github/workflows/build, draft release.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@latest
         with:
           fetch-depth: 0
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.13
+        uses: gittools/actions/gitversion/setup@latest
         with:
           versionSpec: "5.x"
 
       - name: Determine SemVer
-        uses: gittools/actions/gitversion/execute@v0.9.13
+        uses: gittools/actions/gitversion/execute@latest
         with:
           additionalArguments: '/overrideconfig major-version-bump-message="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)" /overrideconfig minor-version-bump-message="^(feat)(\\([\\w\\s]*\\))?:" /overrideconfig patch-version-bump-message="^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:"'
 

--- a/.github/workflows/build, draft release.yml
+++ b/.github/workflows/build, draft release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@latest
+        uses: gittools/actions/checkout@latest
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build, draft release.yml
+++ b/.github/workflows/build, draft release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: gittools/actions/checkout@v0.9.14
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build, draft release.yml
+++ b/.github/workflows/build, draft release.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: gittools/actions/checkout@latest
+        uses: gittools/actions/checkout@v0.9.14
         with:
           fetch-depth: 0
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@latest
+        uses: gittools/actions/gitversion/setup@v0.9.14
         with:
           versionSpec: "5.x"
 
       - name: Determine SemVer
-        uses: gittools/actions/gitversion/execute@latest
+        uses: gittools/actions/gitversion/execute@v0.9.14
         with:
           additionalArguments: '/overrideconfig major-version-bump-message="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)" /overrideconfig minor-version-bump-message="^(feat)(\\([\\w\\s]*\\))?:" /overrideconfig patch-version-bump-message="^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:"'
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@
 -->
 
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - YYYY-MM-DD
+### Added
+- New FAQ in '`README`': 'Which resources does a particular user or group have access to?'
+- New sample code 'MemberOfRecurse.ps1'
 ### Changed
 - When '`ExportFromOnPrem`' is set to '`$true`' and '`ExchangeConnectionUriList`' is not specified, '`ExchangeConnectionUriList`' defaults to '`http://<server>/powershell`' for each Exchange server with the mailbox server role
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,12 +15,11 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - YYYY-MM-DD
+## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - 2022-10-25
 ### Added
+- When '`ExportFromOnPrem`' is set to '`$true`' and '`ExchangeConnectionUriList`' is not specified, '`ExchangeConnectionUriList`' defaults to '`http://<server>/powershell`' for each Exchange server with the mailbox server role
 - New FAQs in '`README`': 'Which resources does a particular user or group have access to?', 'How to find distribution lists without members?'
 - New sample code 'MemberOfRecurse.ps1'
-### Changed
-- When '`ExportFromOnPrem`' is set to '`$true`' and '`ExchangeConnectionUriList`' is not specified, '`ExchangeConnectionUriList`' defaults to '`http://<server>/powershell`' for each Exchange server with the mailbox server role
 
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.2.1" target="_blank">v2.2.1</a> - 2022-09-27
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - YYYY-MM-DD
 ### Added
-- New FAQ in '`README`': 'Which resources does a particular user or group have access to?'
+- New FAQs in '`README`': 'Which resources does a particular user or group have access to?', 'How to find distribution lists without members?'
 - New sample code 'MemberOfRecurse.ps1'
 ### Changed
 - When '`ExportFromOnPrem`' is set to '`$true`' and '`ExchangeConnectionUriList`' is not specified, '`ExchangeConnectionUriList`' defaults to '`http://<server>/powershell`' for each Exchange server with the mailbox server role

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@
   ### Fixed
 -->
 
+## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - YYYY-MM-DD
+### Changed
+- When '`ExportFromOnPrem`' is set to '`$true`' and '`ExchangeConnectionUriList`' is not specified, '`ExchangeConnectionUriList`' defaults to '`http://<server>/powershell`' for each Exchange server with the mailbox server role
+
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.2.1" target="_blank">v2.2.1</a> - 2022-09-27
 ### Fixed
 - When ExportGrantorsWithNoPermissions is enabled and ExportGuids is disabled, empty management role groups were exported with no name and a trailing slash in the recipient type field

--- a/docs/README.md
+++ b/docs/README.md
@@ -220,7 +220,7 @@ Only report results where the filter criteria matches $true.
 
 This filter works against every single row of the results found. ExportFile will only contain lines where this filter returns $true.
 
-The $ExportFileLine contains an object with the header names from $ExportFile as string properties:
+The $ExportFileLine variable contains an object with the header names from $ExportFile as string properties
 - 'Grantor Primary SMTP'
 - 'Grantor Display Name'
 - 'Grantor Exchange GUID' (only when '`ExportGuids`' is enabled)
@@ -240,7 +240,7 @@ The $ExportFileLine contains an object with the header names from $ExportFile as
 - 'Trustee Recipient Type'
 - 'Trustee Environment'
 
-Example: "`$ExportFileFilter.'Trustee Environment' -ieq 'On-Prem'"
+Example: "`$ExportFileLine.'Trustee Environment' -ieq 'On-Prem'"
 
 Default: $null
 ### 1.2.10. ExportMailboxAccessRights

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,11 +133,14 @@ $true for export from on-prem, $false for export from Exchange Online
 
 Default: $false
 ### 1.2.2. ExchangeConnectionUriList
-Server URIs to connect to
+Exchange remote PowerShell URIs to connect to
 
 For on-prem installations, list all Exchange Server Remote PowerShell URIs the script can use
+For Exchange Online, use 'https://outlook.office365.com/powershell-liveid/' or the URI specific to your cloud environment
 
-For Exchange Online use 'https://outlook.office365.com/powershell-liveid/', or the URI specific to your cloud environment
+Default:  
+- If ExportFromOnPrem ist set to false: 'https://outlook.office365.com/powershell-liveid/'
+- If ExportFromOnPrem ist set to true: 'http://\<server\>/powershell' for each Exchange server with the mailbox server role
 ### 1.2.3. ExchangeOnlineConnectionParameters
 This hashtable will be passed as parameter to Connect-ExchangeOnline
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -691,9 +691,9 @@ $params = @{
     TrusteeFilter                               = $null
     ExportFileFilter                            = "
         if ([string]::IsNullOrEmpty(`$ExportFileLine.Permission) -eq `$true) {
-            `$false
+            `$true
         } else {
-            `$true 
+            `$false 
         }
     "
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -690,7 +690,7 @@ $params = @{
     "
     TrusteeFilter                               = $null
     ExportFileFilter                            = "
-        if ([string]::IsNullOrEmpty(`$ExportFileLine.Permissions) -eq `$true) {
+        if ([string]::IsNullOrEmpty(`$ExportFileLine.Permission) -eq `$true) {
             `$false
         } else {
             `$true 

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -1979,7 +1979,8 @@ try {
         ($ExportManagementRoleGroupMembers) -or
         ($ExportDistributionGroupMembers -ieq 'All') -or
         ($ExportDistributionGroupMembers -ieq 'OnlyTrustees') -or
-        ($ExpandGroups)
+        ($ExpandGroups) -or
+        ($ExportGuids)
     ) {
         $AllSecurityPrincipals = [system.collections.arraylist]::Synchronized([system.collections.arraylist]::new($AllRecipients.count))
 

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -325,7 +325,7 @@ Param(
                 $search.Filter = '(&(objectClass=msExchExchangeServer)(msExchCurrentServerRoles:1.2.840.113556.1.4.803:=2))' # all Exchange servers with the mailbox role 
                 $search.PageSize = 1000
                 [void]$search.PropertiesToLoad.Add('networkaddress')
-                @((($search.FindAll().properties.networkaddress | Where-Object { $_ -ilike 'ncacn_ip_tcp:*' }) -ireplace '^ncacn_ip_tcp:', 'http://' -ireplace '$', '/powershell'))
+                @((($search.FindAll().properties.networkaddress | Where-Object { $_ -ilike 'ncacn_ip_tcp:*' }) -ireplace '^ncacn_ip_tcp:', 'http://' -ireplace '$', '/powershell') | Sort-Object -Unique)
             } catch {
                 @()
             }

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -100,10 +100,10 @@ Default: $null
 .PARAMETER ExportFileFilter
 Only report results where the filter criteria matches $true.
 This filter works against every single row of the results found. ExportFile will only contain lines where this filter returns $true.
-The $ExportFileLine contains an object with the header names from $ExportFile as string properties
+The $ExportFileLine variable contains an object with the header names from $ExportFile as string properties
     'Grantor Primary SMTP', 'Grantor Display Name', 'Grantor Recipient Type', 'Grantor Environment', 'Folder', 'Permission', 'Allow/Deny', 'Inherited', 'InheritanceType', 'Trustee Original Identity', 'Trustee Primary SMTP', 'Trustee Display Name', 'Trustee Recipient Type', 'Trustee Environment'
-
-Example: "`$ExportFileFilter.'Trustee Environment' -ieq 'On-Prem'"
+    When GUIDs are exported, additional attributes are available: 'Grantor Exchange GUID', 'Grantor AD ObjectGUID', 'Trustee Exchange GUID', 'Trustee AD ObjectGUID'
+Example: "`$ExportFileLine.'Trustee Environment' -ieq 'On-Prem'"
 Default: $null
 
 

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -1972,7 +1972,15 @@ try {
     Write-Host
     Write-Host "Import security principals, filtered by Name @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
 
-    if (($ExportMailboxAccessRights) -and (($ExportSendAs) -or ($ExportLinkedMasterAccount -and $ExportFromOnPrem) -or ($ExportManagementRoleGroupMembers) -or (($ExportDistributionGroupMembers -ieq 'All') -or ($ExportDistributionGroupMembers -ieq 'OnlyTrustees')) -or ($ExpandGroups))) {
+    if (
+        ($ExportMailboxAccessRights) -or
+        ($ExportSendAs) -or
+        ($ExportLinkedMasterAccount -and $ExportFromOnPrem) -or
+        ($ExportManagementRoleGroupMembers) -or
+        ($ExportDistributionGroupMembers -ieq 'All') -or
+        ($ExportDistributionGroupMembers -ieq 'OnlyTrustees') -or
+        ($ExpandGroups)
+    ) {
         $AllSecurityPrincipals = [system.collections.arraylist]::Synchronized([system.collections.arraylist]::new($AllRecipients.count))
 
         $tempChars = ([char[]](0..255) -clike '[A-Z0-9]')

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -322,7 +322,7 @@ Param(
         if ($ExportFromOnPrem) {
             try {
                 $search = New-Object DirectoryServices.DirectorySearcher([ADSI]"LDAP://$(([ADSI]'LDAP://RootDse').configurationNamingContext)")
-                $search.Filter = '(&(objectClass=msExchExchangeServer)(msExchCurrentServerRoles:1.2.840.113556.1.4.803:=2))' # all Exchange servers with the mailbox role 
+                $search.Filter = '(&(objectClass=msExchExchangeServer)(msExchCurrentServerRoles:1.2.840.113556.1.4.803:=2))' # all Exchange servers with the mailbox role
                 $search.PageSize = 1000
                 [void]$search.PropertiesToLoad.Add('networkaddress')
                 @((($search.FindAll().properties.networkaddress | Where-Object { $_ -ilike 'ncacn_ip_tcp:*' }) -ireplace '^ncacn_ip_tcp:', 'http://' -ireplace '$', '/powershell') | Sort-Object -Unique)
@@ -1066,12 +1066,10 @@ try {
             }
         }
 
-        if ($tempQueue.count -eq 0) {
-            Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-            Write-Host
-        } else {
-            Write-Host
-            Write-Host '    Not all queries have been performed. Enable DebugFile option and check log file.' -ForegroundColor red
+        Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+        if ($tempQueue.count -ne 0) {
+            Write-Host '      Not all queries have been performed. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
         }
 
         foreach ($runspace in $runspaces) {
@@ -1655,12 +1653,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all databases have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all databases have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -1871,12 +1867,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all recipients have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all recipients have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -2154,12 +2148,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '    Not all queries have been performed. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all queries have been performed. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -2433,12 +2425,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '    Not all queries have been performed. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all queries have been performed. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -2861,12 +2851,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all grantor mailboxes have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all grantor mailboxes have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -3330,12 +3318,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all grantor mailboxes have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all grantor mailboxes have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -3833,12 +3819,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all grantors have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all grantors have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -4240,12 +4224,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all grantors have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all grantors have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -4545,12 +4527,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all grantors have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all grantors have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -4905,12 +4885,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all grantors have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all grantors have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -5452,12 +5430,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all Public Folders have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all Public Folders have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -5770,12 +5746,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all recipients have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all recipients have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -6032,12 +6006,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '    Not all groups have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all groups have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -6392,12 +6364,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all management role group members have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all management role group members have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -6747,12 +6717,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all distribution groups have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all distribution groups have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -7059,12 +7027,10 @@ try {
                 }
             }
 
-            if ($tempQueue.count -eq 0) {
-                Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                Write-Host
-            } else {
-                Write-Host
-                Write-Host '  Not all files have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+            Write-Host (("`b" * 100) + ('    {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+            if ($tempQueue.count -ne 0) {
+                Write-Host '    Not all files have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
             }
 
             foreach ($runspace in $runspaces) {
@@ -7322,12 +7288,10 @@ try {
                     }
                 }
 
-                if ($tempQueue.count -eq 0) {
-                    Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                    Write-Host
-                } else {
-                    Write-Host
-                    Write-Host '    Not all recipients have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+                Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+                if ($tempQueue.count -ne 0) {
+                    Write-Host '      Not all recipients have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
                 }
 
                 foreach ($runspace in $runspaces) {
@@ -7593,12 +7557,10 @@ try {
                     }
                 }
 
-                if ($tempQueue.count -eq 0) {
-                    Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                    Write-Host
-                } else {
-                    Write-Host
-                    Write-Host '    Not all Public Folders have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+                Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+                if ($tempQueue.count -ne 0) {
+                    Write-Host '      Not all Public Folders have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
                 }
 
                 foreach ($runspace in $runspaces) {
@@ -7858,12 +7820,10 @@ try {
                     }
                 }
 
-                if ($tempQueue.count -eq 0) {
-                    Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                    Write-Host
-                } else {
-                    Write-Host
-                    Write-Host '    Not all Management Role Groups have been checked. Enable DebugFile option and check log file.' -ForegroundColor red
+                Write-Host (("`b" * 100) + ('      {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+                if ($tempQueue.count -ne 0) {
+                    Write-Host '      Not all Management Role Groups have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
                 }
 
                 foreach ($runspace in $runspaces) {
@@ -8078,12 +8038,10 @@ try {
                     }
                 }
 
-                if ($tempQueue.count -eq 0) {
-                    Write-Host (("`b" * 100) + ('          {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'))) -NoNewline
-                    Write-Host
-                } else {
-                    Write-Host
-                    Write-Host '        Not all files have been combined. Enable DebugFile option and check log file.' -ForegroundColor red
+                Write-Host (("`b" * 100) + ('          {0:0000000} @{1}@' -f $tempQueueCount, $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')))
+
+                if ($tempQueue.count -ne 0) {
+                    Write-Host '          Not all files have been checked. Enable ErrorFile and DebugFile options and check the log files.' -ForegroundColor red
                 }
 
                 foreach ($runspace in $runspaces) {

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -2908,7 +2908,7 @@ try {
         for ($x = 0; $x -lt $AllRecipients.count; $x++) {
             $Recipient = $AllRecipients[$x]
 
-            if (($Recipient.RecipientTypeDetails.Value -ilike '*Mailbox') -and ($x -in $GrantorsToConsider) -and ($Recipient.RecipientTypeDetails.Value -ine 'PublicFolderMailbox') -and (-not $Recipient.WhenSoftDeleted)) {
+            if (($Recipient.RecipientTypeDetails.Value -ilike '*Mailbox') -and ($x -in $GrantorsToConsider) -and ($Recipient.RecipientTypeDetails.Value -inotin @('PublicFolderMailbox', 'MonitoringMailbox')) -and (-not $Recipient.WhenSoftDeleted)) {
                 $tempQueue.enqueue($x)
             }
         }

--- a/src/sample code/other samples/MemberOfRecurse.ps1
+++ b/src/sample code/other samples/MemberOfRecurse.ps1
@@ -416,15 +416,14 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
 
                     foreach ($fsp in $Search.FindAll()) {
                         if (($fsp.path -ne '') -and ($null -ne $fsp.path)) {
-                            # Foreign Security Principals do not have the tokengroups attribute
-                            # We need to switch to another, slower search method
-                            # member:1.2.840.113556.1.4.1941:= (LDAP_MATCHING_RULE_IN_CHAIN) returns groups containing a specific DN as member
                             # A Foreign Security Principal ist created in each (sub)domain, in which it is granted permissions,
-                            # and it can only be member of a domain local group - so we set the searchroot to the (sub)domain of the Foreign Security Principal.
+                            #   and it can only be member of a domain local group - so we set the searchroot to the (sub)domain of the Foreign Security Principal.
+                            # Foreign Security Principals do not have the tokengroups attribute, which would not contain domain local groups anyhow
+                            # member:1.2.840.113556.1.4.1941:= (LDAP_MATCHING_RULE_IN_CHAIN) returns groups containing a specific DN as member, incl. nesting
                             Write-Verbose "      Found ForeignSecurityPrincipal $($fsp.properties.cn) in $((($fsp.path -split ',DC=')[1..999] -join '.'))"
                             try {
                                 $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$((($fsp.path -split ',DC=')[1..999] -join '.'))")
-                                $Search.filter = "(&(groupType:1.2.840.113556.1.4.803:=4)(member:1.2.840.113556.1.4.1941:=$($fsp.Properties.distinguishedname)))"
+                                $Search.filter = "(&(objectClass=group)(groupType:1.2.840.113556.1.4.803:=4)(member:1.2.840.113556.1.4.1941:=$($fsp.Properties.distinguishedname)))"
 
                                 foreach ($group in $Search.findall()) {
                                     $sid = New-Object System.Security.Principal.SecurityIdentifier($group.properties.objectsid[0], 0).value

--- a/src/sample code/other samples/MemberOfRecurse.ps1
+++ b/src/sample code/other samples/MemberOfRecurse.ps1
@@ -1,28 +1,31 @@
-# List of domains to check for group membership.
-# If the first entry in the list is '*', all outgoing and bidirectional trusts in the current user's forest are considered.
-# If a string starts with a minus or dash ('-domain-a.local'), the domain after the dash or minus is removed from the list (no wildcards allowed).
-# All domains belonging to the Active Directory forest of the currently logged in user are always considered, but specific domains can be removed (`'*', '-childA1.childA.user.forest'`).
-# When a cross-forest trust is detected by the '*' option, all domains belonging to the trusted forest are considered but specific domains can be removed (`'*', '-childX.trusted.forest'`).
-# Default value: '*'
-$TrustsToCheckForGroups = @('*')
+[CmdletBinding(PositionalBinding = $false)]
 
 
-$AdObjectsToCheck = @(
-    # Accepted string formats (examples are in this order):
-    #   Distinguished Name
-    #   Canonical name
-    #   Domain\SamAccountName (pre Windows 2000 logon name, NT4 logon name)
-    #   User Principal Name (UPN)
-    #   AD Object GUID (in curly braces)
-    #   SID or SIDHistory
-    'CN=Jeff Smith,CN=users,DC=example,DC=com',
-    'example.com/Users/Hank Morgan',
-    'EXAMPLE\GruberMa',
-    'John.Carpenter@example.com',
-    '{95ee9fff-3436-11d1-b2b0-d15ae3ac8436}',
-    'S-1-5-21-1180699209-877415012-3182924384-1004'
+Param(
+    # If the first entry in the list is '*', all outgoing and bidirectional trusts in the current user's forest are considered.
+    # If a string starts with a minus or dash ('-domain-a.local'), the domain after the dash or minus is removed from the list (no wildcards allowed).
+    # All domains belonging to the Active Directory forest of the currently logged in user are always considered, but specific domains can be removed (`'*', '-childA1.childA.user.forest'`).
+    # When a cross-forest trust is detected by the '*' option, all domains belonging to the trusted forest are considered but specific domains can be removed (`'*', '-childX.trusted.forest'`).
+    # Default value: '*'
+    [string[]]$TrustsToCheckForGroups = @('*'),
+
+
+    [string[]]$AdObjectsToCheck = @(
+        # Accepted string formats (examples are in this order):
+        #   Distinguished Name
+        #   Canonical name
+        #   Domain\SamAccountName (pre Windows 2000 logon name, NT4 logon name)
+        #   User Principal Name (UPN)
+        #   AD Object GUID (in curly braces)
+        #   SID or SIDHistory
+        'CN=Jeff Smith,CN=users,DC=example,DC=com',
+        'example.com/Users/Hank Morgan',
+        'EXAMPLE\GruberMa',
+        'John.Carpenter@example.com',
+        '{95ee9fff-3436-11d1-b2b0-d15ae3ac8436}',
+        'S-1-5-21-1180699209-877415012-3182924384-1004'
+    )
 )
-
 
 function CheckADConnectivity {
     param (
@@ -93,13 +96,7 @@ function CheckADConnectivity {
                             $TrustsToCheckForGroups.remove($data[0])
                         }
 
-                        if ($InternalTrustsToCheckForDomainLocalGroups -icontains $data[0]) {
-                            $InternalTrustsToCheckForDomainLocalGroups.remove($data[0])
-                        }
-
-                        if ($ExternalTrustsToCheckForDomainLocalGroups -icontains $data[0]) {
-                            $ExternalTrustsToCheckForDomainLocalGroups.remove($data[0])
-                        }
+                        $LookupDomainsToTrusts.remove($data[0])
 
                         $returnvalue = $false
                     }
@@ -112,190 +109,256 @@ function CheckADConnectivity {
 }
 
 
+function ConvertSidToGuidAndFillResult {
+    param (
+        $sid,
+        $AdObjectToCheckDn,
+        $indent
+    )
+
+    try {
+        $objTrans = New-Object -ComObject 'NameTranslate'
+        $objNT = $objTrans.GetType()
+        $null = $objNT.InvokeMember('Init', 'InvokeMethod', $Null, $objTrans, (3, $null))
+        $null = $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (8, "$($sid)"))
+        $GroupGuid = $($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 7).trimstart('{').trimend('}'))
+        Write-Verbose "$indent$($GroupGuid)"
+        $script:MemberOfRecurse += $('"' + (
+                @(
+                    @(
+                        $($ADObjectToCheck),
+                        $($GroupGuid),
+                        $($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 2))
+                    ) | ForEach-Object { $_ -replace '"', '""' }
+                ) -join '";"'
+            ) + '"')
+        $script:SIDsToCheckInTrusts += $sid
+    } catch {
+        try {
+            # Non-domain-specific well-known SID with a domain specific ObjectGUID?
+            $SidHex = @()
+            $ot = New-Object System.Security.Principal.SecurityIdentifier($Sid)
+            $c = New-Object 'byte[]' $ot.BinaryLength
+            $ot.GetBinaryForm($c, 0)
+            foreach ($char in $c) {
+                $SidHex += $('\{0:x2}' -f $char)
+            }
+
+            $local:Search = New-Object DirectoryServices.DirectorySearcher
+            $local:Search.PageSize = 1000
+            $local:Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$(($($AdObjectToCheckDn) -split ',DC=')[1..999] -join '.')")
+            $local:Search.filter = "(&(objectclass=group)(objectsid=$($SidHex -join '')))"
+
+            @('canonicalname', 'objectguid') | ForEach-Object {
+                if (-not $local:search.PropertiesToLoad.Contains($_)) {
+                    $null = $local:search.PropertiesToLoad.add($_)
+                }
+            }
+            $Group = $local:search.FindOne()
+            $GroupGuid = [guid]::new($Group.Properties.objectguid[0]).guid
+            Write-Verbose "$indent$($GroupGuid)"
+            $script:MemberOfRecurse += $('"' + (
+                    @(
+                        @(
+                            $($ADObjectToCheck),
+                            $($GroupGuid),
+                            $($Group.Properties.canonicalname)
+                        ) | ForEach-Object { $_ -replace '"', '""' }
+                    ) -join '";"'
+                ) + '"')
+        } catch {
+            Write-Verbose "$indent$($_ | Out-String)"
+        }
+    }
+}
+
+
 # Setup
 $script:jobs = New-Object System.Collections.ArrayList
 Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 $Search = New-Object DirectoryServices.DirectorySearcher
 $Search.PageSize = 1000
-$MemberOfRecurse = @()
+$script:MemberOfRecurse = @()
 
 
 Write-Host "Enumerate domains @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
 $x = $TrustsToCheckForGroups
 [System.Collections.ArrayList]$TrustsToCheckForGroups = @()
-[System.Collections.ArrayList]$InternalTrustsToCheckForDomainLocalGroups = @()
-if ($GraphOnly -eq $false) {
-    # Users own domain/forest is always included
-    try {
-        $objTrans = New-Object -ComObject 'NameTranslate'
-        $objNT = $objTrans.GetType()
-        $objNT.InvokeMember('Init', 'InvokeMethod', $Null, $objTrans, (3, $Null)) # 3 = ADS_NAME_INITTYPE_GC
-        $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (12, $(([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value))) # 12 = ADS_NAME_TYPE_SID_OR_SID_HISTORY_NAME
-        $y = (([ADSI]"LDAP://$(($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 1) -split ',DC=')[1..999] -join '.')/RootDSE").rootDomainNamingContext -replace ('DC=', '') -replace (',', '.')).tolower()
+$LookupDomainsToTrusts = @{}
+# Users own domain/forest is always included
+try {
+    $objTrans = New-Object -ComObject 'NameTranslate'
+    $objNT = $objTrans.GetType()
+    $objNT.InvokeMember('Init', 'InvokeMethod', $Null, $objTrans, (3, $Null)) # 3 = ADS_NAME_INITTYPE_GC
+    $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (12, $(([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value))) # 12 = ADS_NAME_TYPE_SID_OR_SID_HISTORY_NAME
+    $UserForest = (([ADSI]"LDAP://$(($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 1) -split ',DC=')[1..999] -join '.')/RootDSE").rootDomainNamingContext -replace ('DC=', '') -replace (',', '.')).tolower()
 
-        if ($y -ne '') {
-            Write-Host "  User forest: $y"
-            $TrustsToCheckForGroups += $y.tolower()
+    if ($UserForest -ne '') {
+        Write-Host "  User forest: $UserForest"
+        $TrustsToCheckForGroups += $UserForest.tolower()
+        $LookupDomainsToTrusts.add($UserForest, $UserForest)
 
-            # Internal trusts
-            $Search.SearchRoot = "GC://$($TrustsToCheckForGroups[0])"
-            $Search.Filter = '(ObjectClass=trustedDomain)'
+        $Search.SearchRoot = "GC://$($UserForest)"
+        $Search.Filter = '(ObjectClass=trustedDomain)'
 
-            foreach ($TrustedDomain in $Search.FindAll()) {
-                # Only intra-forest trusts
-                if ($TrustedDomain.properties.trustattributes -eq 32) {
-                    $InternalTrustsToCheckForDomainLocalGroups += $TrustedDomain.properties.name.tolower()
+        $TrustedDomains = @(
+            @($Search.FindAll()) | Sort-Object @{Expression = {
+                    $TemporaryArray = @($_.properties.name.Split('.'))
+                    [Array]::Reverse($TemporaryArray)
+                    $TemporaryArray
                 }
             }
+        )
 
-            $InternalTrustsToCheckForDomainLocalGroups = @(
-                $InternalTrustsToCheckForDomainLocalGroups | Select-Object -Unique | Sort-Object @{Expression = {
-                        $TemporaryArray = @($_.Split('.'))
-                        [Array]::Reverse($TemporaryArray)
-                        $TemporaryArray
-                    }
-                }
-            )
-
-            foreach ($InternalTrustToCheckForDomainLocalGroups in $InternalTrustsToCheckForDomainLocalGroups) {
-                if ($InternalTrustToCheckForDomainLocalGroups -ine $y) {
-                    Write-Host "    Child domain: $($InternalTrustToCheckForDomainLocalGroups)"
-                }
+        # Internal trusts
+        foreach ($TrustedDomain in $TrustedDomains) {
+            if (($TrustedDomain.properties.trustattributes -eq 32) -and ($TrustedDomain.properties.name -ine $UserForest) -and (-not $LookupDomainsToTrusts.ContainsKey($TrustedDomain.properties.name.tolower()))) {
+                Write-Host "    Child domain: $($TrustedDomain.properties.name.tolower())"
+                $LookupDomainsToTrusts.add($TrustedDomain.properties.name.tolower(), $UserForest)
             }
+        }
 
-            # Other domains - either the list provided, or all outgoing and bidirectional trusts
-            if ($x[0] -eq '*') {
-                $Search.SearchRoot = "GC://$($TrustsToCheckForGroups[0])"
-                $Search.Filter = '(ObjectClass=trustedDomain)'
+        # Other trusts
+        if ($x[0] -eq '*') {
+            foreach ($TrustedDomain in $TrustedDomains) {
+                # No intra-forest trusts, only bidirectional trusts and outbound trusts
+                if (($($TrustedDomain.properties.trustattributes) -ne 32) -and (($($TrustedDomain.properties.trustdirection) -eq 2) -or ($($TrustedDomain.properties.trustdirection) -eq 3)) ) {
+                    if ($TrustedDomain.properties.trustattributes -eq 8) {
+                        # Cross-forest trust
+                        Write-Host "  Trusted forest: $($TrustedDomain.properties.name.tolower())"
+                        if ("-$($TrustedDomain.properties.name)" -iin $x) {
+                            Write-Host "    Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name.tolower())'"
+                        } else {
+                            $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
+                            $LookupDomainsToTrusts.add($TrustedDomain.properties.name.tolower(), $TrustedDomain.properties.name.tolower())
+                        }
 
-                $TrustedDomains = @(
-                    @($Search.FindAll()) | Sort-Object @{Expression = {
-                            $TemporaryArray = @($_.properties.name.Split('.'))
-                            [Array]::Reverse($TemporaryArray)
-                            $TemporaryArray
+                        $temp = @(
+                            @(@(Resolve-DnsName -Name "_gc._tcp.$($TrustedDomain.properties.name)" -Type srv).nametarget) | ForEach-Object { ($_ -split '\.')[1..999] -join '.' } | Where-Object { $_ -ine $TrustedDomain.properties.name } | Select-Object -Unique | Sort-Object @{Expression = {
+                                    $TemporaryArray = @($_.Split('.'))
+                                    [Array]::Reverse($TemporaryArray)
+                                    $TemporaryArray
+                                }
+                            }
+                        )
+
+                        $temp | ForEach-Object {
+                            Write-Host "    Child domain: $($_.tolower())"
+                            $LookupDomainsToTrusts.add($_.tolower(), $TrustedDomain.properties.name.tolower())
+                        }
+                    } else {
+                        # No cross-forest trust
+                        Write-Host "  Trusted domain: $($TrustedDomain.properties.name)"
+                        if ("-$($TrustedDomain.properties.name)" -iin $x) {
+                            Write-Host "    Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name)'"
+                        } else {
+                            $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
+                            $LookupDomainsToTrusts.add($TrustedDomain.properties.name.tolower(), $TrustedDomain.properties.name.tolower())
                         }
                     }
-                )
+                }
+            }
+        }
 
-                foreach ($TrustedDomain in $TrustedDomains) {
-                    # DNS name of the other side of the trust (could be the root domain or any subdomain)
-                    # $TrustName = $TrustedDomain.properties.name
+        for ($a = 0; $a -lt $x.Count; $a++) {
+            if (($a -eq 0) -and ($x[$a] -ieq '*')) {
+                continue
+            }
 
-                    # Domain SID of the other side of the trust
-                    # $TrustNameSID = (New-Object system.security.principal.securityidentifier($($TrustedDomain.properties.securityidentifier), 0)).value
+            $y = ($x[$a] -replace ('DC=', '') -replace (',', '.')).tolower()
 
-                    # Trust direction
-                    # https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.trustdirection?view=net-5.0
-                    # $TrustDirectionNumber = $TrustedDomain.properties.trustdirection
+            if ($y -eq $x[$a]) {
+                Write-Host "  User provided trusted domain/forest: $y"
+            } else {
+                Write-Host "  User provided trusted domain/forest: $($x[$a]) -> $y"
+            }
 
-                    # Trust type
-                    # https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.trusttype?view=net-5.0
-                    # $TrustTypeNumber = $TrustedDomain.properties.trusttype
+            if (($a -ne 0) -and ($x[$a] -ieq '*')) {
+                Write-Host '    Entry * is only allowed at first position in list. Skip entry.' -ForegroundColor Red
+                continue
+            }
 
-                    # Trust attributes
-                    # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/e9a2d23c-c31e-4a6f-88a0-6646fdb51a3c
-                    # $TrustAttributesNumber = $TrustedDomain.properties.trustattributes
+            if ($y -match '[^a-zA-Z0-9.-]') {
+                Write-Host '    Allowed characters are a-z, A-Z, ., -. Skip entry.' -ForegroundColor Red
+                continue
+            }
 
-                    # Which domains does the current user have access to?
-                    # No intra-forest trusts, only bidirectional trusts and outbound trusts
-
-                    if (($($TrustedDomain.properties.trustattributes) -ne 32) -and (($($TrustedDomain.properties.trustdirection) -eq 2) -or ($($TrustedDomain.properties.trustdirection) -eq 3)) ) {
-                        if ($TrustedDomain.properties.trustattributes -eq 8) {
-                            # Cross-forest trust
-                            Write-Host "  Trusted forest: $($TrustedDomain.properties.name)"
-                            if ("-$($TrustedDomain.properties.name)" -iin $x) {
-                                Write-Host "    Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name)'"
-                            } else {
-                                $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
-                            }
-
-                            $temp = @(
-                                @(@(Resolve-DnsName -Name "_gc._tcp.$($TrustedDomain.properties.name)" -Type srv).nametarget) | ForEach-Object { ($_ -split '\.')[1..999] -join '.' } | Where-Object { $_ -ine $TrustedDomain.properties.name } | Select-Object -Unique | Sort-Object @{Expression = {
-                                        $TemporaryArray = @($_.Split('.'))
-                                        [Array]::Reverse($TemporaryArray)
-                                        $TemporaryArray
+            if (-not ($y.StartsWith('-'))) {
+                if ($TrustsToCheckForGroups -icontains $y) {
+                    Write-Host '    Trusted domain/forest already in list.' -ForegroundColor Yellow
+                } else {
+                    if ($TrustedDomains.properties.name -icontains $y) {
+                        foreach ($TrustedDomain in @($TrustedDomains | Where-Object { $_.properties.name -ieq $y })) {
+                            # No intra-forest trusts, only bidirectional trusts and outbound trusts
+                            if (($($TrustedDomain.properties.trustattributes) -ne 32) -and (($($TrustedDomain.properties.trustdirection) -eq 2) -or ($($TrustedDomain.properties.trustdirection) -eq 3)) ) {
+                                if ($TrustedDomain.properties.trustattributes -eq 8) {
+                                    # Cross-forest trust
+                                    Write-Host "    Trusted forest: $($TrustedDomain.properties.name)"
+                                    if ("-$($TrustedDomain.properties.name)" -iin $x) {
+                                        Write-Host "      Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name)'"
+                                    } else {
+                                        $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
+                                        $LookupDomainsToTrusts.add($TrustedDomain.properties.name.tolower(), $TrustedDomain.properties.name.tolower())
+                                    }
+            
+                                    $temp = @(
+                                        @(@(Resolve-DnsName -Name "_gc._tcp.$($TrustedDomain.properties.name)" -Type srv).nametarget) | ForEach-Object { ($_ -split '\.')[1..999] -join '.' } | Where-Object { $_ -ine $TrustedDomain.properties.name } | Select-Object -Unique | Sort-Object @{Expression = {
+                                                $TemporaryArray = @($_.Split('.'))
+                                                [Array]::Reverse($TemporaryArray)
+                                                $TemporaryArray
+                                            }
+                                        }
+                                    )
+            
+                                    $temp | ForEach-Object {
+                                        Write-Host "      Child domain: $($_.tolower())"
+                                        $LookupDomainsToTrusts.add($_.tolower(), $TrustedDomain.properties.name.tolower())
+                                    }
+                                } else {
+                                    # No cross-forest trust
+                                    Write-Host "    Trusted domain: $($TrustedDomain.properties.name)"
+                                    if ("-$($TrustedDomain.properties.name)" -iin $x) {
+                                        Write-Host "      Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name)'"
+                                    } else {
+                                        $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
+                                        $LookupDomainsToTrusts.add($TrustedDomain.properties.name.tolower(), $TrustedDomain.properties.name.tolower())
                                     }
                                 }
-                            )
-
-                            $temp | ForEach-Object {
-                                Write-Host "    Child domain: $($_.tolower())"
-                            }
-                        } else {
-                            # No cross-forest trust
-                            Write-Host "  Trusted domain: $($TrustedDomain.properties.name)"
-                            if ("-$($TrustedDomain.properties.name)" -iin $x) {
-                                Write-Host "    Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name)'"
-                            } else {
-                                $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
                             }
                         }
-                    }
-                }
-            }
-
-            for ($a = 0; $a -lt $x.Count; $a++) {
-                if (($a -eq 0) -and ($x[$a] -ieq '*')) {
-                    continue
-                }
-
-                $y = ($x[$a] -replace ('DC=', '') -replace (',', '.')).tolower()
-
-                if ($y -eq $x[$a]) {
-                    Write-Host "  User provided trusted domain/forest: $y"
-                } else {
-                    Write-Host "  User provided trusted domain/forest: $($x[$a]) -> $y"
-                }
-
-                if (($a -ne 0) -and ($x[$a] -ieq '*')) {
-                    Write-Host '    Entry * is only allowed at first position in list. Skip entry.' -ForegroundColor Red
-                    continue
-                }
-
-                if ($y -match '[^a-zA-Z0-9.-]') {
-                    Write-Host '    Allowed characters are a-z, A-Z, ., -. Skip entry.' -ForegroundColor Red
-                    continue
-                }
-
-                if (-not ($y.StartsWith('-'))) {
-                    if ($TrustsToCheckForGroups -icontains $y) {
-                        Write-Host '    Trusted domain/forest already in list.' -ForegroundColor Yellow
                     } else {
-                        $TrustsToCheckForGroups += $y.tolower()
+                        Write-Host '    No trust to this domain/forest found.' -ForegroundColor Yellow
                     }
-                } else {
-                    Write-Host '    Remove trusted domain/forest.'
-                    for ($z = 0; $z -lt $TrustsToCheckForGroups.Count; $z++) {
-                        if ($TrustsToCheckForGroups[$z] -ieq $y.substring(1)) {
-                            $TrustsToCheckForGroups[$z] = ''
-                        }
+                }
+            } else {
+                Write-Host '    Remove trusted domain/forest.'
+                for ($z = 0; $z -lt $TrustsToCheckForGroups.Count; $z++) {
+                    if ($TrustsToCheckForGroups[$z] -ieq $y.substring(1)) {
+                        $TrustsToCheckForGroups.RemoveAt($z)
+                        $LookupDomainsToTrusts = $LookupDomainsToTrusts.GetEnumerator() | Where-Object { $_.Value -ine $y.substring(1) }
                     }
                 }
             }
-
-            $TrustsToCheckForGroups = @($TrustsToCheckForGroups | Where-Object { $_ })
-
-
-            Write-Host
-            Write-Host "Check trusts for open LDAP port and connectivity @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-            CheckADConnectivity @(@(@($TrustsToCheckForGroups) + @($InternalTrustsToCheckForDomainLocalGroups)) | Select-Object -Unique) 'LDAP' '  ' | Out-Null
-
-
-            Write-Host
-            Write-Host "Check trusts for open Global Catalog port and connectivity @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-            CheckADConnectivity $TrustsToCheckForGroups 'GC' '  ' | Out-Null
-            # $InternalTrustsToCheckForDomainLocalGroups does not need to be checked for GC connectivity, as local groups can only be queried via LDAP
-        } else {
-            Write-Host '  Problem connecting to logged in user''s Active Directory (no error message, but forest root domain name is empty), assuming Graph/Azure AD from now on.' -ForegroundColor Yellow
-            $GraphOnly = $true
         }
-    } catch {
-        $y = ''
-        Write-Verbose $error[0]
-        Write-Host '  Problem connecting to logged in user''s Active Directory (see verbose stream for error message), assuming Graph/Azure AD from now on.' -ForegroundColor Yellow
-        $GraphOnly = $true
+
+        $TrustsToCheckForGroups = @($TrustsToCheckForGroups | Where-Object { $_ })
+
+
+        Write-Host
+        Write-Host "Check trusts for open LDAP port and connectivity @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+        CheckADConnectivity @(@(@($TrustsToCheckForGroups) + @($LookupDomainsToTrusts.GetEnumerator() | ForEach-Object { $_.Name })) | Select-Object -Unique) 'LDAP' '  ' | Out-Null
+
+
+        Write-Host
+        Write-Host "Check trusts for open Global Catalog port and connectivity @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+        CheckADConnectivity $TrustsToCheckForGroups 'GC' '  ' | Out-Null
     }
+} catch {
+    $y = ''
+    Write-Verbose $error[0]
+    Write-Host '  Problem connecting to logged in user''s Active Directory (see verbose stream for error message).' -ForegroundColor Yellow
 }
+
 
 
 Write-Host
@@ -306,7 +369,6 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
     try {
         $AdObjectToCheckDn = $null
         $AdObjectToCheckGuid = $null
-        $objResult = $null
 
         # Get DN of AD object
         $objTrans = New-Object -ComObject 'NameTranslate'
@@ -315,11 +377,19 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
         $null = $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (8, "$($AdObjectToCheck)"))
         $AdObjectToCheckDn = $objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 1)
         $AdObjectToCheckGuid = $objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 7).trimstart('{').trimend('}')
-        $MemberOfRecurse += "$($ADObjectToCheck);;$($AdObjectToCheckGuid)"
+        $script:MemberOfRecurse += $('"' + (
+                @(
+                    @(
+                        $($ADObjectToCheck),
+                        $($ADObjectToCheckGuid),
+                        $($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 2))
+                    ) | ForEach-Object { $_ -replace '"', '""' }
+                ) -join '";"'
+            ) + '"')
+        
+        $script:SIDsToCheckInTrusts = @()
 
-        # Setup
-        $GroupsSids = @()
-        $SIDsToCheckInTrusts = @()
+        Write-Verbose "    $($LookupDomainsToTrusts[$(($($AdObjectToCheckDn) -split ',DC=')[1..999] -join '.')]) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
 
         # Security groups, no matter if enabled for mail or not
         Write-Verbose "      Security groups via LDAP query of tokengroups attribute @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
@@ -328,8 +398,7 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
         foreach ($sidBytes in $UserAccount.Properties.tokengroups) {
             $sid = (New-Object System.Security.Principal.SecurityIdentifier($sidbytes, 0)).value
             Write-Verbose "        $sid"
-            $GroupsSIDs += $sid
-            $SIDsToCheckInTrusts += $sid
+            ConvertSidToGuidAndFillResult $sid $AdObjectToCheckDn '          '
         }
 
         # Distribution groups (static only)
@@ -340,52 +409,47 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
             if ($DistributionGroup.properties.objectsid) {
                 $sid = (New-Object System.Security.Principal.SecurityIdentifier $($DistributionGroup.properties.objectsid), 0).value
                 Write-Verbose "        $sid"
-                $GroupsSIDs += $sid
-                $SIDsToCheckInTrusts += $sid
+                ConvertSidToGuidAndFillResult $sid $AdObjectToCheckDn '          '
             }
 
             foreach ($SidHistorySid in @($DistributionGroup.properties.sidhistory | Where-Object { $_ })) {
                 $sid = (New-Object System.Security.Principal.SecurityIdentifier $SidHistorySid, 0).value
                 Write-Verbose "        $sid"
-                $GroupsSIDs += $sid
-                $SIDsToCheckInTrusts += $sid
+                ConvertSidToGuidAndFillResult $sid $AdObjectToCheckDn '          '
             }
         }
 
-        # Domain local groups in the current user's forest
-        Write-Verbose "      Domain local groups in the current user's forest via LDAP query @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-        foreach ($InternalTrustToCheckForDomainLocalGroups in $InternalTrustsToCheckForDomainLocalGroups) {
-            Write-Verbose "        $($InternalTrustToCheckForDomainLocalGroups) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-            $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$($InternalTrustToCheckForDomainLocalGroups)")
+        # Domain local groups
+        Write-Verbose "      Domain local groups via LDAP query @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+        foreach ($DomainToCheckForDomainLocalGroups in @(($LookupDomainsToTrusts.GetEnumerator() | Where-Object { $_.Value -ieq $LookupDomainsToTrusts[$(($($AdObjectToCheckDn) -split ',DC=')[1..999] -join '.')] }).name)) {
+            Write-Verbose "        $($DomainToCheckForDomainLocalGroups) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+            $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$($DomainToCheckForDomainLocalGroups)")
             $Search.filter = "(&(objectClass=group)(groupType:1.2.840.113556.1.4.803:=4)(member:1.2.840.113556.1.4.1941:=$($AdObjectToCheckDn)))"
             foreach ($LocalGroup in $search.findall()) {
                 if ($LocalGroup.properties.objectsid) {
                     $sid = (New-Object System.Security.Principal.SecurityIdentifier $($LocalGroup.properties.objectsid), 0).value
                     Write-Verbose "          $sid"
-                    $GroupsSIDs += $sid
-                    $SIDsToCheckInTrusts += $sid
+                    ConvertSidToGuidAndFillResult $sid $AdObjectToCheckDn '            '
                 }
 
                 foreach ($SidHistorySid in @($LocalGroup.properties.sidhistory | Where-Object { $_ })) {
                     $sid = (New-Object System.Security.Principal.SecurityIdentifier $SidHistorySid, 0).value
                     Write-Verbose "          $sid"
-                    $GroupsSIDs += $sid
-                    $SIDsToCheckInTrusts += $sid
+                    ConvertSidToGuidAndFillResult $sid $AdObjectToCheckDn '            '
                 }
             }
         }
 
-        $GroupsSIDs = @($GroupsSIDs | Select-Object -Unique)
-        $SIDsToCheckInTrusts = @($SIDsToCheckInTrusts | Select-Object -Unique)
+        $script:SIDsToCheckInTrusts = @($script:SIDsToCheckInTrusts | Select-Object -Unique)
 
         # Loop through all domains to check if the mailbox account has a group membership there
         # Across a trust, a user can only be added to a domain local group.
         # Domain local groups can not be used outside their own domain, so we don't need to query recursively
         # But when it's a cross-forest trust, we need to query every every domain on that other side of the trust
         #   This is handled before by adding every single domain of a cross-forest trusted forest to $TrustsToCheckForGroups
-        if ($SIDsToCheckInTrusts.count -gt 0) {
+        if ($script:SIDsToCheckInTrusts.count -gt 0) {
             $LdapFilterSIDs = '(|'
-            foreach ($SidToCheckInTrusts in $SIDsToCheckInTrusts) {
+            foreach ($SidToCheckInTrusts in $script:SIDsToCheckInTrusts) {
                 try {
                     $SidHex = @()
                     $ot = New-Object System.Security.Principal.SecurityIdentifier($SidToCheckInTrusts)
@@ -395,7 +459,7 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
                         $SidHex += $('\{0:x2}' -f $char)
                     }
                     # Foreign Security Principals have an objectSID, but no sIDHistory
-                    # The sIDHistory of the current object is part of $SIDsToCheckInTrusts and therefore also considered in $LdapFilterSIDs
+                    # The sIDHistory of the current object is part of $script:SIDsToCheckInTrusts and therefore also considered in $LdapFilterSIDs
                     $LdapFilterSIDs += ('(objectsid=' + $($SidHex -join '') + ')')
                 } catch {
                     Write-Host '      Error creating LDAP filter for search across trusts.' -ForegroundColor Red
@@ -409,56 +473,44 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
 
         if ($LdapFilterSids -ilike '*(objectsid=*') {
             # Across each trust, search for all Foreign Security Principals matching a SID from our list
-            for ($DomainNumber = 0; $DomainNumber -lt $TrustsToCheckForGroups.count; $DomainNumber++) {
-                if (($TrustsToCheckForGroups[$DomainNumber] -ne '') -and ($TrustsToCheckForGroups[$DomainNumber] -ine $UserDomain) -and ($UserDomain -ne '')) {
-                    Write-Host "    $($TrustsToCheckForGroups[$DomainNumber]) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-                    $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("GC://$($TrustsToCheckForGroups[$DomainNumber])")
-                    $Search.filter = "(&(objectclass=foreignsecurityprincipal)$LdapFilterSIDs)"
+            foreach ($TrustToCheckForFSPs in @(($LookupDomainsToTrusts.GetEnumerator() | Where-Object { $_.Value -ine $LookupDomainsToTrusts[$(($($AdObjectToCheckDn) -split ',DC=')[1..999] -join '.')] }).value | Select-Object -Unique)) {
+                Write-Host "    $($TrustToCheckForFSPs) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+                $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("GC://$($TrustToCheckForFSPs)")
+                $Search.filter = "(&(objectclass=foreignsecurityprincipal)$LdapFilterSIDs)"
 
-                    foreach ($fsp in $Search.FindAll()) {
-                        if (($fsp.path -ne '') -and ($null -ne $fsp.path)) {
-                            # A Foreign Security Principal (FSP) is created in each (sub)domain in which it is granted permissions
-                            # A FSP it can only be member of a domain local group - so we set the searchroot to the (sub)domain of the Foreign Security Principal
-                            # FSPs have on tokengroups attribute, which would not contain domain local groups anyhow
-                            # member:1.2.840.113556.1.4.1941:= (LDAP_MATCHING_RULE_IN_CHAIN) returns groups containing a specific DN as member, incl. nesting
-                            Write-Verbose "      Found ForeignSecurityPrincipal $($fsp.properties.cn) in $((($fsp.path -split ',DC=')[1..999] -join '.'))"
-                            
+                foreach ($fsp in $Search.FindAll()) {
+                    if (($fsp.path -ne '') -and ($null -ne $fsp.path)) {
+                        # A Foreign Security Principal (FSP) is created in each (sub)domain in which it is granted permissions
+                        # A FSP it can only be member of a domain local group - so we set the searchroot to the (sub)domain of the Foreign Security Principal
+                        # FSPs have on tokengroups attribute, which would not contain domain local groups anyhow
+                        # member:1.2.840.113556.1.4.1941:= (LDAP_MATCHING_RULE_IN_CHAIN) returns groups containing a specific DN as member, incl. nesting
+                        Write-Verbose "      Found ForeignSecurityPrincipal $($fsp.properties.cn) in $((($fsp.path -split ',DC=')[1..999] -join '.'))"
+
+                        if ($((($fsp.path -split ',DC=')[1..999] -join '.')) -iin @(($LookupDomainsToTrusts.GetEnumerator() | Where-Object { $_.Value -ine $LookupDomainsToTrusts[$(($($AdObjectToCheckDn) -split ',DC=')[1..999] -join '.')] }).name)) {
                             try {
                                 $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$((($fsp.path -split ',DC=')[1..999] -join '.'))")
                                 $Search.filter = "(&(objectClass=group)(groupType:1.2.840.113556.1.4.803:=4)(member:1.2.840.113556.1.4.1941:=$($fsp.Properties.distinguishedname)))"
 
                                 foreach ($group in $Search.findall()) {
-                                    $sid = New-Object System.Security.Principal.SecurityIdentifier($group.properties.objectsid[0], 0).value
+                                    $sid = (New-Object System.Security.Principal.SecurityIdentifier $($group.properties.objectsid), 0).value
                                     Write-Verbose "        $sid"
-                                    $GroupsSIDs += $sid
+                                    ConvertSidToGuidAndFillResult $sid $AdObjectToCheckDn '          '
 
                                     foreach ($SidHistorySid in @($group.properties.sidhistory | Where-Object { $_ })) {
                                         $sid = (New-Object System.Security.Principal.SecurityIdentifier $SidHistorySid, 0).value
                                         Write-Verbose "        $sid"
-                                        $GroupsSIDs += $sid
+                                        ConvertSidToGuidAndFillResult $sid $AdObjectToCheckDn '          '
                                     }
-
                                 }
                             } catch {
                                 Write-Host "        Error: $($error[0].exception)" -ForegroundColor red
                             }
+                        } else {
+                            Write-Verbose "        Ignoring, because '$($fsp.path)' is not part of a trust in TrustsToCheckForGroups."
                         }
                     }
                 }
             }
-        }
-
-
-        # Translate SIDs to GUIDs
-        Write-Verbose "      SIDs to GUIDs @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-        foreach ($GroupSid in $GroupsSids) {
-            $objTrans = New-Object -ComObject 'NameTranslate'
-            $objNT = $objTrans.GetType()
-            $null = $objNT.InvokeMember('Init', 'InvokeMethod', $Null, $objTrans, (3, $null))
-            $null = $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (8, "$($GroupSid)"))
-            $GroupGuid = $($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 7).trimstart('{').trimend('}'))
-            Write-Verbose "      $($GroupSid): $($GroupGuid)"
-            $MemberOfRecurse += "$($ADObjectToCheck);$($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 3));$($GroupGuid)"
         }
     } catch {
         @(
@@ -466,8 +518,7 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
             "$($_ | Out-String)",
             "AdObjectToCheck: $($AdObjectToCheck)",
             "AdObjectToCheckDn: $($AdObjectToCheckDn)",
-            "AdObjectToCheckGuid $($AdObjectToCheckGuid)",
-            "objResult.properties.'msds-principalname': $($objResult.properties.'msds-principalname')"
+            "AdObjectToCheckGuid $($AdObjectToCheckGuid)"
         ) | ForEach-Object {
             Write-Host "    $_" -ForegroundColor Red
         }
@@ -477,9 +528,9 @@ foreach ($AdObjectToCheck in $AdObjectsToCheck) {
 
 Write-Host
 Write-Host "Final MemberOfRecurse result @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-$MemberOfRecurse = $MemberOfRecurse | Select-Object -Unique
-$MemberOfRecurse = $MemberOfRecurse | Select-Object -Unique | ConvertFrom-Csv -Delimiter ';' -Header @('Original object', 'MemberOf recurse NT4 name', 'MemberOf recurse AD GUID')
-$MemberOfRecurse | Out-String -Stream | ForEach-Object { Write-Output "  $_" }
+$script:MemberOfRecurse = $script:MemberOfRecurse | Select-Object -Unique
+$script:MemberOfRecurse = $script:MemberOfRecurse | Select-Object -Unique | ConvertFrom-Csv -Delimiter ';' -Header @('Original object', 'MemberOf recurse AD GUID', 'MemberOf recurse group')
+$script:MemberOfRecurse
 
 
 Write-Host
@@ -516,7 +567,7 @@ $params = @{
     RecipientProperties                         = @()
     GrantorFilter                               = $null
     TrusteeFilter                               = $null
-    ExportFileFilter                            = "if (`$ExportFileLine.'Trustee AD ObjectGUID' -iin $('@(''' + (@($MemberOfRecurse.'MemberOf recurse AD GUID') -join ''', ''') + ''')')) { `$true } else { `$false }"
+    ExportFileFilter                            = "if (`$ExportFileLine.'Trustee AD ObjectGUID' -iin $('@(''' + (@($script:MemberOfRecurse.'MemberOf recurse AD GUID') -join ''', ''') + ''')')) { `$true } else { `$false }"
 
     ExportFile                                  = '.\export\Export-RecipientPermissions_Result_MemberOfRecurse.csv'
     ErrorFile                                   = '.\export\Export-RecipientPermissions_Error_MemberOfRecurse.csv'

--- a/src/sample code/other samples/MemberOfRecurse.ps1
+++ b/src/sample code/other samples/MemberOfRecurse.ps1
@@ -1,0 +1,535 @@
+# List of domains to check for group membership.
+# If the first entry in the list is '*', all outgoing and bidirectional trusts in the current user's forest are considered.
+# If a string starts with a minus or dash ('-domain-a.local'), the domain after the dash or minus is removed from the list (no wildcards allowed).
+# All domains belonging to the Active Directory forest of the currently logged in user are always considered, but specific domains can be removed (`'*', '-childA1.childA.user.forest'`).
+# When a cross-forest trust is detected by the '*' option, all domains belonging to the trusted forest are considered but specific domains can be removed (`'*', '-childX.trusted.forest'`).
+# Default value: '*'
+$TrustsToCheckForGroups = @('*')
+
+
+$AdObjectsToCheck = @(
+    # Accepted string formats (examples are in this order):
+    #   Distinguished Name
+    #   Canonical name
+    #   Domain\SamAccountName (pre Windows 2000 logon name, NT4 logon name)
+    #   User Principal Name (UPN)
+    #   AD Object GUID (in curly braces)
+    #   SID or SIDHistory
+    'CN=Jeff Smith,CN=users,DC=example,DC=com',
+    'example.com/Users/Hank Morgan',
+    'EXAMPLE\GruberMa',
+    'John.Carpenter@example.com',
+    '{95ee9fff-3436-11d1-b2b0-d15ae3ac8436}',
+    'S-1-5-21-1180699209-877415012-3182924384-1004'
+)
+
+
+function CheckADConnectivity {
+    param (
+        [array]$CheckDomains,
+        [string]$CheckProtocolText,
+        [string]$Indent
+    )
+    [void][runspacefactory]::CreateRunspacePool()
+    $RunspacePool = [runspacefactory]::CreateRunspacePool(1, 25)
+    $RunspacePool.Open()
+
+    for ($DomainNumber = 0; $DomainNumber -lt $CheckDomains.count; $DomainNumber++) {
+        if ($($CheckDomains[$DomainNumber]) -eq '') {
+            continue
+        }
+
+        $PowerShell = [powershell]::Create()
+        $PowerShell.RunspacePool = $RunspacePool
+
+        [void]$PowerShell.AddScript( {
+                Param (
+                    [string]$CheckDomain,
+                    [string]$CheckProtocolText
+                )
+                $DebugPreference = 'Continue'
+                Write-Debug "Start(Ticks) = $((Get-Date).Ticks)"
+                Write-Output "$CheckDomain"
+                $Search = New-Object DirectoryServices.DirectorySearcher
+                $Search.PageSize = 1000
+                $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("$($CheckProtocolText)://$CheckDomain")
+                $Search.filter = '(objectclass=user)'
+                try {
+                    $UserAccount = ([ADSI]"$(($Search.FindOne()).path)")
+                    Write-Output 'QueryPassed'
+                } catch {
+                    Write-Output 'QueryFailed'
+                }
+            }).AddArgument($($CheckDomains[$DomainNumber])).AddArgument($CheckProtocolText)
+        $Object = New-Object 'System.Management.Automation.PSDataCollection[psobject]'
+        $Handle = $PowerShell.BeginInvoke($Object, $Object)
+        $temp = '' | Select-Object PowerShell, Handle, Object, StartTime, Done
+        $temp.PowerShell = $PowerShell
+        $temp.Handle = $Handle
+        $temp.Object = $Object
+        $temp.StartTime = $null
+        $temp.Done = $false
+        [void]$script:jobs.Add($Temp)
+    }
+    while (($script:jobs.Done | Where-Object { $_ -eq $false }).count -ne 0) {
+        foreach ($job in $script:jobs) {
+            if (($null -eq $job.StartTime) -and ($job.Powershell.Streams.Debug[0].Message -match 'Start')) {
+                $StartTicks = $job.powershell.Streams.Debug[0].Message -replace '[^0-9]'
+                $job.StartTime = [Datetime]::MinValue + [TimeSpan]::FromTicks($StartTicks)
+            }
+
+            if ($null -ne $job.StartTime) {
+                if ((($job.handle.IsCompleted -eq $true) -and ($job.Done -eq $false)) -or (($job.Done -eq $false) -and ((New-TimeSpan -Start $job.StartTime -End (Get-Date)).TotalSeconds -ge 5))) {
+                    $data = $job.Object[0..$(($job.object).count - 1)]
+                    Write-Host "$Indent$($data[0])"
+                    if ($data -icontains 'QueryPassed') {
+                        Write-Host "$Indent  $CheckProtocolText query successful"
+                        $returnvalue = $true
+                    } else {
+                        Write-Host "$Indent  $CheckProtocolText query failed, remove domain from list." -ForegroundColor Red
+                        Write-Host "$Indent  If this error is permanent, check firewalls, DNS and AD trust. Consider parameter TrustsToCheckForGroups." -ForegroundColor Red
+
+                        if ($TrustsToCheckForGroups -icontains $data[0]) {
+                            $TrustsToCheckForGroups.remove($data[0])
+                        }
+
+                        if ($InternalTrustsToCheckForDomainLocalGroups -icontains $data[0]) {
+                            $InternalTrustsToCheckForDomainLocalGroups.remove($data[0])
+                        }
+
+                        if ($ExternalTrustsToCheckForDomainLocalGroups -icontains $data[0]) {
+                            $ExternalTrustsToCheckForDomainLocalGroups.remove($data[0])
+                        }
+
+                        $returnvalue = $false
+                    }
+                    $job.Done = $true
+                }
+            }
+        }
+    }
+    return $returnvalue
+}
+
+
+# Setup
+$script:jobs = New-Object System.Collections.ArrayList
+Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+$Search = New-Object DirectoryServices.DirectorySearcher
+$Search.PageSize = 1000
+$MemberOfRecurse = @()
+
+
+Write-Host "Enumerate domains @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+$x = $TrustsToCheckForGroups
+[System.Collections.ArrayList]$TrustsToCheckForGroups = @()
+[System.Collections.ArrayList]$InternalTrustsToCheckForDomainLocalGroups = @()
+if ($GraphOnly -eq $false) {
+    # Users own domain/forest is always included
+    try {
+        $objTrans = New-Object -ComObject 'NameTranslate'
+        $objNT = $objTrans.GetType()
+        $objNT.InvokeMember('Init', 'InvokeMethod', $Null, $objTrans, (3, $Null)) # 3 = ADS_NAME_INITTYPE_GC
+        $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (12, $(([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value))) # 12 = ADS_NAME_TYPE_SID_OR_SID_HISTORY_NAME
+        $y = (([ADSI]"LDAP://$(($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 1) -split ',DC=')[1..999] -join '.')/RootDSE").rootDomainNamingContext -replace ('DC=', '') -replace (',', '.')).tolower()
+
+        if ($y -ne '') {
+            Write-Host "  User forest: $y"
+            $TrustsToCheckForGroups += $y.tolower()
+
+            # Internal trusts
+            $Search.SearchRoot = "GC://$($TrustsToCheckForGroups[0])"
+            $Search.Filter = '(ObjectClass=trustedDomain)'
+
+            foreach ($TrustedDomain in $Search.FindAll()) {
+                # Only intra-forest trusts
+                if ($TrustedDomain.properties.trustattributes -eq 32) {
+                    $InternalTrustsToCheckForDomainLocalGroups += $TrustedDomain.properties.name.tolower()
+                }
+            }
+
+            $InternalTrustsToCheckForDomainLocalGroups = @(
+                $InternalTrustsToCheckForDomainLocalGroups | Select-Object -Unique | Sort-Object @{Expression = {
+                        $TemporaryArray = @($_.Split('.'))
+                        [Array]::Reverse($TemporaryArray)
+                        $TemporaryArray
+                    }
+                }
+            )
+
+            foreach ($InternalTrustToCheckForDomainLocalGroups in $InternalTrustsToCheckForDomainLocalGroups) {
+                if ($InternalTrustToCheckForDomainLocalGroups -ine $y) {
+                    Write-Host "    Child domain: $($InternalTrustToCheckForDomainLocalGroups)"
+                }
+            }
+
+            # Other domains - either the list provided, or all outgoing and bidirectional trusts
+            if ($x[0] -eq '*') {
+                $Search.SearchRoot = "GC://$($TrustsToCheckForGroups[0])"
+                $Search.Filter = '(ObjectClass=trustedDomain)'
+
+                $TrustedDomains = @(
+                    @($Search.FindAll()) | Sort-Object @{Expression = {
+                            $TemporaryArray = @($_.properties.name.Split('.'))
+                            [Array]::Reverse($TemporaryArray)
+                            $TemporaryArray
+                        }
+                    }
+                )
+
+                foreach ($TrustedDomain in $TrustedDomains) {
+                    # DNS name of the other side of the trust (could be the root domain or any subdomain)
+                    # $TrustName = $TrustedDomain.properties.name
+
+                    # Domain SID of the other side of the trust
+                    # $TrustNameSID = (New-Object system.security.principal.securityidentifier($($TrustedDomain.properties.securityidentifier), 0)).value
+
+                    # Trust direction
+                    # https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.trustdirection?view=net-5.0
+                    # $TrustDirectionNumber = $TrustedDomain.properties.trustdirection
+
+                    # Trust type
+                    # https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectory.trusttype?view=net-5.0
+                    # $TrustTypeNumber = $TrustedDomain.properties.trusttype
+
+                    # Trust attributes
+                    # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/e9a2d23c-c31e-4a6f-88a0-6646fdb51a3c
+                    # $TrustAttributesNumber = $TrustedDomain.properties.trustattributes
+
+                    # Which domains does the current user have access to?
+                    # No intra-forest trusts, only bidirectional trusts and outbound trusts
+
+                    if (($($TrustedDomain.properties.trustattributes) -ne 32) -and (($($TrustedDomain.properties.trustdirection) -eq 2) -or ($($TrustedDomain.properties.trustdirection) -eq 3)) ) {
+                        if ($TrustedDomain.properties.trustattributes -eq 8) {
+                            # Cross-forest trust
+                            Write-Host "  Trusted forest: $($TrustedDomain.properties.name)"
+                            if ("-$($TrustedDomain.properties.name)" -iin $x) {
+                                Write-Host "    Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name)'"
+                            } else {
+                                $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
+                            }
+
+                            $temp = @(
+                                @(@(Resolve-DnsName -Name "_gc._tcp.$($TrustedDomain.properties.name)" -Type srv).nametarget) | ForEach-Object { ($_ -split '\.')[1..999] -join '.' } | Where-Object { $_ -ine $TrustedDomain.properties.name } | Select-Object -Unique | Sort-Object @{Expression = {
+                                        $TemporaryArray = @($_.Split('.'))
+                                        [Array]::Reverse($TemporaryArray)
+                                        $TemporaryArray
+                                    }
+                                }
+                            )
+
+                            $temp | ForEach-Object {
+                                Write-Host "    Child domain: $($_.tolower())"
+                            }
+                        } else {
+                            # No cross-forest trust
+                            Write-Host "  Trusted domain: $($TrustedDomain.properties.name)"
+                            if ("-$($TrustedDomain.properties.name)" -iin $x) {
+                                Write-Host "    Ignoring because of TrustsToCheckForGroups entry '-$($TrustedDomain.properties.name)'"
+                            } else {
+                                $TrustsToCheckForGroups += $TrustedDomain.properties.name.tolower()
+                            }
+                        }
+                    }
+                }
+            }
+
+            for ($a = 0; $a -lt $x.Count; $a++) {
+                if (($a -eq 0) -and ($x[$a] -ieq '*')) {
+                    continue
+                }
+
+                $y = ($x[$a] -replace ('DC=', '') -replace (',', '.')).tolower()
+
+                if ($y -eq $x[$a]) {
+                    Write-Host "  User provided trusted domain/forest: $y"
+                } else {
+                    Write-Host "  User provided trusted domain/forest: $($x[$a]) -> $y"
+                }
+
+                if (($a -ne 0) -and ($x[$a] -ieq '*')) {
+                    Write-Host '    Entry * is only allowed at first position in list. Skip entry.' -ForegroundColor Red
+                    continue
+                }
+
+                if ($y -match '[^a-zA-Z0-9.-]') {
+                    Write-Host '    Allowed characters are a-z, A-Z, ., -. Skip entry.' -ForegroundColor Red
+                    continue
+                }
+
+                if (-not ($y.StartsWith('-'))) {
+                    if ($TrustsToCheckForGroups -icontains $y) {
+                        Write-Host '    Trusted domain/forest already in list.' -ForegroundColor Yellow
+                    } else {
+                        $TrustsToCheckForGroups += $y.tolower()
+                    }
+                } else {
+                    Write-Host '    Remove trusted domain/forest.'
+                    for ($z = 0; $z -lt $TrustsToCheckForGroups.Count; $z++) {
+                        if ($TrustsToCheckForGroups[$z] -ieq $y.substring(1)) {
+                            $TrustsToCheckForGroups[$z] = ''
+                        }
+                    }
+                }
+            }
+
+            $TrustsToCheckForGroups = @($TrustsToCheckForGroups | Where-Object { $_ })
+
+
+            Write-Host
+            Write-Host "Check trusts for open LDAP port and connectivity @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+            CheckADConnectivity @(@(@($TrustsToCheckForGroups) + @($InternalTrustsToCheckForDomainLocalGroups)) | Select-Object -Unique) 'LDAP' '  ' | Out-Null
+
+
+            Write-Host
+            Write-Host "Check trusts for open Global Catalog port and connectivity @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+            CheckADConnectivity $TrustsToCheckForGroups 'GC' '  ' | Out-Null
+            # $InternalTrustsToCheckForDomainLocalGroups does not need to be checked for GC connectivity, as local groups can only be queried via LDAP
+        } else {
+            Write-Host '  Problem connecting to logged in user''s Active Directory (no error message, but forest root domain name is empty), assuming Graph/Azure AD from now on.' -ForegroundColor Yellow
+            $GraphOnly = $true
+        }
+    } catch {
+        $y = ''
+        Write-Verbose $error[0]
+        Write-Host '  Problem connecting to logged in user''s Active Directory (see verbose stream for error message), assuming Graph/Azure AD from now on.' -ForegroundColor Yellow
+        $GraphOnly = $true
+    }
+}
+
+
+Write-Host
+Write-Host "Enumerate group membership @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+foreach ($AdObjectToCheck in $AdObjectsToCheck) {
+    Write-Host "  '$($AdObjectToCheck)' @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+
+    try {
+        $AdObjectToCheckDn = $null
+        $AdObjectToCheckGuid = $null
+        $objResult = $null
+
+        # Get DN of AD object
+        $objTrans = New-Object -ComObject 'NameTranslate'
+        $objNT = $objTrans.GetType()
+        $null = $objNT.InvokeMember('Init', 'InvokeMethod', $Null, $objTrans, (3, $null))
+        $null = $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (8, "$($AdObjectToCheck)"))
+        $AdObjectToCheckDn = $objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 1)
+        $AdObjectToCheckGuid = $objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 7).trimstart('{').trimend('}')
+        $MemberOfRecurse += "$($ADObjectToCheck);;$($AdObjectToCheckGuid)"
+
+        # Setup
+        $GroupsSids = @()
+        $SIDsToCheckInTrusts = @()
+
+        # Security groups, no matter if enabled for mail or not
+        Write-Verbose "      Security groups via LDAP query of tokengroups attribute @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+        $UserAccount = [ADSI]"LDAP://$($AdObjectToCheckDn)"
+        $UserAccount.GetInfoEx(@('tokengroups'), 0)
+        foreach ($sidBytes in $UserAccount.Properties.tokengroups) {
+            $sid = (New-Object System.Security.Principal.SecurityIdentifier($sidbytes, 0)).value
+            Write-Verbose "        $sid"
+            $GroupsSIDs += $sid
+            $SIDsToCheckInTrusts += $sid
+        }
+
+        # Distribution groups (static only)
+        Write-Verbose "      Distribution groups (static only) via GC query @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+        $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("GC://$(($($AdObjectToCheckDn) -split ',DC=')[1..999] -join '.')")
+        $Search.filter = "(&(objectClass=group)(!(groupType:1.2.840.113556.1.4.803:=2147483648))(member:1.2.840.113556.1.4.1941:=$($AdObjectToCheckDn)))"
+        foreach ($DistributionGroup in $search.findall()) {
+            if ($DistributionGroup.properties.objectsid) {
+                $sid = (New-Object System.Security.Principal.SecurityIdentifier $($DistributionGroup.properties.objectsid), 0).value
+                Write-Verbose "        $sid"
+                $GroupsSIDs += $sid
+                $SIDsToCheckInTrusts += $sid
+            }
+
+            foreach ($SidHistorySid in @($DistributionGroup.properties.sidhistory | Where-Object { $_ })) {
+                $sid = (New-Object System.Security.Principal.SecurityIdentifier $SidHistorySid, 0).value
+                Write-Verbose "        $sid"
+                $GroupsSIDs += $sid
+                $SIDsToCheckInTrusts += $sid
+            }
+        }
+
+        # Domain local groups in the current user's forest
+        Write-Verbose "      Domain local groups in the current user's forest via LDAP query @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+        foreach ($InternalTrustToCheckForDomainLocalGroups in $InternalTrustsToCheckForDomainLocalGroups) {
+            Write-Verbose "        $($InternalTrustToCheckForDomainLocalGroups) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+            $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$($InternalTrustToCheckForDomainLocalGroups)")
+            $Search.filter = "(&(objectClass=group)(groupType:1.2.840.113556.1.4.803:=4)(member:1.2.840.113556.1.4.1941:=$($AdObjectToCheckDn)))"
+            foreach ($LocalGroup in $search.findall()) {
+                if ($LocalGroup.properties.objectsid) {
+                    $sid = (New-Object System.Security.Principal.SecurityIdentifier $($LocalGroup.properties.objectsid), 0).value
+                    Write-Verbose "          $sid"
+                    $GroupsSIDs += $sid
+                    $SIDsToCheckInTrusts += $sid
+                }
+
+                foreach ($SidHistorySid in @($LocalGroup.properties.sidhistory | Where-Object { $_ })) {
+                    $sid = (New-Object System.Security.Principal.SecurityIdentifier $SidHistorySid, 0).value
+                    Write-Verbose "          $sid"
+                    $GroupsSIDs += $sid
+                    $SIDsToCheckInTrusts += $sid
+                }
+            }
+        }
+
+        $GroupsSIDs = @($GroupsSIDs | Select-Object -Unique)
+        $SIDsToCheckInTrusts = @($SIDsToCheckInTrusts | Select-Object -Unique)
+
+        # Loop through all domains to check if the mailbox account has a group membership there
+        # Across a trust, a user can only be added to a domain local group.
+        # Domain local groups can not be used outside their own domain, so we don't need to query recursively
+        # But when it's a cross-forest trust, we need to query every every domain on that other side of the trust
+        #   This is handled before by adding every single domain of a cross-forest trusted forest to $TrustsToCheckForGroups
+        if ($SIDsToCheckInTrusts.count -gt 0) {
+            $LdapFilterSIDs = '(|'
+            foreach ($SidToCheckInTrusts in $SIDsToCheckInTrusts) {
+                try {
+                    $SidHex = @()
+                    $ot = New-Object System.Security.Principal.SecurityIdentifier($SidToCheckInTrusts)
+                    $c = New-Object 'byte[]' $ot.BinaryLength
+                    $ot.GetBinaryForm($c, 0)
+                    foreach ($char in $c) {
+                        $SidHex += $('\{0:x2}' -f $char)
+                    }
+                    # Foreign Security Principals have an objectSID, but no sIDHistory
+                    # The sIDHistory of the current object is part of $SIDsToCheckInTrusts and therefore also considered in $LdapFilterSIDs
+                    $LdapFilterSIDs += ('(objectsid=' + $($SidHex -join '') + ')')
+                } catch {
+                    Write-Host '      Error creating LDAP filter for search across trusts.' -ForegroundColor Red
+                    $error[0]
+                }
+            }
+            $LdapFilterSIDs += ')'
+        } else {
+            $LdapFilterSIDs = ''
+        }
+
+        if ($LdapFilterSids -ilike '*(objectsid=*') {
+            for ($DomainNumber = 0; $DomainNumber -lt $TrustsToCheckForGroups.count; $DomainNumber++) {
+                if (($TrustsToCheckForGroups[$DomainNumber] -ne '') -and ($TrustsToCheckForGroups[$DomainNumber] -ine $UserDomain) -and ($UserDomain -ne '')) {
+                    Write-Host "    $($TrustsToCheckForGroups[$DomainNumber]) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+                    $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("GC://$($TrustsToCheckForGroups[$DomainNumber])")
+                    $Search.filter = "(&(objectclass=foreignsecurityprincipal)$LdapFilterSIDs)"
+
+                    foreach ($fsp in $Search.FindAll()) {
+                        if (($fsp.path -ne '') -and ($null -ne $fsp.path)) {
+                            # Foreign Security Principals do not have the tokengroups attribute
+                            # We need to switch to another, slower search method
+                            # member:1.2.840.113556.1.4.1941:= (LDAP_MATCHING_RULE_IN_CHAIN) returns groups containing a specific DN as member
+                            # A Foreign Security Principal ist created in each (sub)domain, in which it is granted permissions,
+                            # and it can only be member of a domain local group - so we set the searchroot to the (sub)domain of the Foreign Security Principal.
+                            Write-Verbose "      Found ForeignSecurityPrincipal $($fsp.properties.cn) in $((($fsp.path -split ',DC=')[1..999] -join '.'))"
+                            try {
+                                $Search.searchroot = New-Object System.DirectoryServices.DirectoryEntry("LDAP://$((($fsp.path -split ',DC=')[1..999] -join '.'))")
+                                $Search.filter = "(&(groupType:1.2.840.113556.1.4.803:=4)(member:1.2.840.113556.1.4.1941:=$($fsp.Properties.distinguishedname)))"
+
+                                foreach ($group in $Search.findall()) {
+                                    $sid = New-Object System.Security.Principal.SecurityIdentifier($group.properties.objectsid[0], 0).value
+                                    Write-Verbose "        $sid"
+                                    $GroupsSIDs += $sid
+
+                                    foreach ($SidHistorySid in @($group.properties.sidhistory | Where-Object { $_ })) {
+                                        $sid = (New-Object System.Security.Principal.SecurityIdentifier $SidHistorySid, 0).value
+                                        Write-Verbose "        $sid"
+                                        $GroupsSIDs += $sid
+                                    }
+
+                                }
+                            } catch {
+                                Write-Host "        Error: $($error[0].exception)" -ForegroundColor red
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+        # Translate SIDs to GUIDs
+        Write-Verbose "      SIDs to GUIDs @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+        foreach ($GroupSid in $GroupsSids) {
+            $objTrans = New-Object -ComObject 'NameTranslate'
+            $objNT = $objTrans.GetType()
+            $null = $objNT.InvokeMember('Init', 'InvokeMethod', $Null, $objTrans, (3, $null))
+            $null = $objNT.InvokeMember('Set', 'InvokeMethod', $Null, $objTrans, (8, "$($GroupSid)"))
+            $GroupGuid = $($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 7).trimstart('{').trimend('}'))
+            Write-Verbose "      $($GroupSid): $($GroupGuid)"
+            $MemberOfRecurse += "$($ADObjectToCheck);$($objNT.InvokeMember('Get', 'InvokeMethod', $Null, $objTrans, 3));$($GroupGuid)"
+        }
+    } catch {
+        @(
+            'ERROR',
+            "$($_ | Out-String)",
+            "AdObjectToCheck: $($AdObjectToCheck)",
+            "AdObjectToCheckDn: $($AdObjectToCheckDn)",
+            "AdObjectToCheckGuid $($AdObjectToCheckGuid)",
+            "objResult.properties.'msds-principalname': $($objResult.properties.'msds-principalname')"
+        ) | ForEach-Object {
+            Write-Host "    $_" -ForegroundColor Red
+        }
+    }
+}
+
+
+Write-Host
+Write-Host "Final MemberOfRecurse result @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+$MemberOfRecurse = $MemberOfRecurse | Select-Object -Unique
+$MemberOfRecurse = $MemberOfRecurse | Select-Object -Unique | ConvertFrom-Csv -Delimiter ';' -Header @('Original object', 'MemberOf recurse NT4 name', 'MemberOf recurse AD GUID')
+$MemberOfRecurse | Out-String -Stream | ForEach-Object { Write-Output "  $_" }
+
+
+Write-Host
+Write-Host "Configure and start Export-RecipientPermissions (demo) @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+$params = @{
+    ExportFromOnPrem                            = $true
+    UseDefaultCredential                        = $true
+
+    ExportMailboxAccessRights                   = $true
+    ExportMailboxAccessRightsSelf               = $false
+    ExportMailboxAccessRightsInherited          = $true
+    ExportMailboxFolderPermissions              = $true
+    ExportMailboxFolderPermissionsAnonymous     = $false
+    ExportMailboxFolderPermissionsDefault       = $false
+    ExportMailboxFolderPermissionsOwnerAtLocal  = $false
+    ExportMailboxFolderPermissionsMemberAtLocal = $false
+    ExportSendAs                                = $true
+    ExportSendAsSelf                            = $false
+    ExportSendOnBehalf                          = $true
+    ExportManagedBy                             = $true
+    ExportLinkedMasterAccount                   = $true
+    ExportPublicFolderPermissions               = $true
+    ExportPublicFolderPermissionsAnonymous      = $false
+    ExportPublicFolderPermissionsDefault        = $false
+    ExportForwarders                            = $true
+    ExportManagementRoleGroupMembers            = $true
+    ExportDistributionGroupMembers              = 'None'
+    ExportGroupMembersRecurse                   = $false
+    ExpandGroups                                = $false
+    ExportGuids                                 = $true
+    ExportGrantorsWithNoPermissions             = $false
+    ExportTrustees                              = 'All'
+
+    RecipientProperties                         = @()
+    GrantorFilter                               = $null
+    TrusteeFilter                               = $null
+    ExportFileFilter                            = "if (`$ExportFileLine.'Trustee AD ObjectGUID' -iin $('@(''' + (@($MemberOfRecurse.'MemberOf recurse AD GUID') -join ''', ''') + ''')')) { `$true } else { `$false }"
+
+    ExportFile                                  = '.\export\Export-RecipientPermissions_Result_MemberOfRecurse.csv'
+    ErrorFile                                   = '.\export\Export-RecipientPermissions_Error_MemberOfRecurse.csv'
+    DebugFile                                   = $null
+
+    verbose                                     = $false
+}
+
+Write-Host '  Parameters ($params hashtable)'
+$params | Out-String -Stream | ForEach-Object { Write-Host "  $($_.trim())" }
+
+Write-Host '  Run Export-RecipientPermissions with parameters from $params (demo)'
+Write-Host "    '& ..\..\Export-RecipientPermissions.ps1 @params'"
+
+
+Write-Host
+Write-Host "End script @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"


### PR DESCRIPTION
## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - 2022-10-25
### Added
- When '`ExportFromOnPrem`' is set to '`$true`' and '`ExchangeConnectionUriList`' is not specified, '`ExchangeConnectionUriList`' defaults to '`http://<server>/powershell`' for each Exchange server with the mailbox server role
- New FAQs in '`README`': 'Which resources does a particular user or group have access to?', 'How to find distribution lists without members?'
- New sample code 'MemberOfRecurse.ps1'