### PR TITLE
v2.3.1

### DIFF
--- a/.github/workflows/build, draft release.yml
+++ b/.github/workflows/build, draft release.yml
@@ -15,12 +15,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.14
+        uses: gittools/actions/gitversion/setup@v0.9.15
         with:
           versionSpec: "5.x"
 
       - name: Determine SemVer
-        uses: gittools/actions/gitversion/execute@v0.9.14
+        uses: gittools/actions/gitversion/execute@v0.9.15
         with:
           additionalArguments: '/overrideconfig major-version-bump-message="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)" /overrideconfig minor-version-bump-message="^(feat)(\\([\\w\\s]*\\))?:" /overrideconfig patch-version-bump-message="^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s]*\\))?:"'
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -58,7 +58,7 @@ function main {
         $tempFileContent = $tempFileContent -replace 'XXXRemoveWhenBuildingXXX-->', ''
         $tempFileContent | Set-Content $($_[0])
         # convert to HTML
-        & pandoc.exe $($_[0]) --resource-path=".;docs" -f gfm -t html --self-contained -H .\build\pandoc_header.html --css .\build\pandoc_css_empty.css --metadata pagetitle="$(([System.IO.FileInfo]"$($_[0])").basename) - $(($env:GITHUB_REPOSITORY -split '/')[1])" -o $($_[1])
+        & pandoc.exe $($_[0]) --resource-path=".;docs" -f gfm -t html --embed-resources --standalone -H .\build\pandoc_header.html --css .\build\pandoc_css_empty.css --metadata pagetitle="$(([System.IO.FileInfo]"$($_[0])").basename) - $(($env:GITHUB_REPOSITORY -split '/')[1])" -o $($_[1])
     }
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,8 +16,11 @@
 -->
 
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/vX.X.X" target="_blank">vX.X.X</a> - YYYY-MM-DD
+### Added
+- New FAQ in '`README`': 'How to export permissions for specific public folders?'
 ### Fixed
 - Sample code '`compare.ps1`' now additionally outputs the original identity of a trustee and not only the primary SMTP address. This helps with permissions granted to 'Anonymous' and 'Default', as well as with recipients which have been deleted in the time between the old and the new export.
+- Always include trustee groups in GrantorFilter when ExportDistributionGroups is set to OnlyTrustees
 
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - 2022-10-25
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,12 +15,12 @@
   ### Fixed
 -->
 
-## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/vX.X.X" target="_blank">vX.X.X</a> - YYYY-MM-DD
+## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.1" target="_blank">v2.3.1</a> - 2022-11-28
 ### Added
 - New FAQ in '`README`': 'How to export permissions for specific public folders?'
 ### Fixed
 - Sample code '`compare.ps1`' now additionally outputs the original identity of a trustee and not only the primary SMTP address. This helps with permissions granted to 'Anonymous' and 'Default', as well as with recipients which have been deleted in the time between the old and the new export.
-- Always include trustee groups in GrantorFilter when ExportDistributionGroups is set to OnlyTrustees
+- Always include trustee groups in '`GrantorFilter`' when '`ExportDistributionGroups`' is set to '`OnlyTrustees`'
 
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - 2022-10-25
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@
   ### Fixed
 -->
 
+## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/vX.X.X" target="_blank">vX.X.X</a> - YYYY-MM-DD
+### Fixed
+- Sample code '`compare.ps1`' now additionally outputs the original identity of a trustee and not only the primary SMTP address. This helps with permissions granted to 'Anonymous' and 'Default', as well as with recipients which have been deleted in the time between the old and the new export.
+
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.0" target="_blank">v2.3.0</a> - 2022-10-25
 ### Added
 - When '`ExportFromOnPrem`' is set to '`$true`' and '`ExchangeConnectionUriList`' is not specified, '`ExchangeConnectionUriList`' defaults to '`http://<server>/powershell`' for each Exchange server with the mailbox server role

--- a/src/sample code/Compare-RecipientPermissions/Compare-RecipientPermissions.ps1
+++ b/src/sample code/Compare-RecipientPermissions/Compare-RecipientPermissions.ps1
@@ -21,12 +21,11 @@ Param(
     $newCsv = '.\Export-RecipientPermissions_Output_new.csv',
 
     # Display results on screen before creating file showing changes
-    $DisplayResults = $false,
-
+    $DisplayResults = $true,
 
     # Path for export file showing changes
     # Set to '' or $null to not create this file
-    $ChangeFile = '.\changes.csv'
+    $ChangeFile = '.\comparison.csv'
 )
 
 
@@ -91,11 +90,11 @@ if ($DisplayResults) {
         Write-Host "  $($GrantorPrimarySmtp)"
         foreach ($DatasetObject in $Dataset[$($GrantorPrimarySmtpOrder.IndexOf($GrantorPrimarySmtp))..$($GrantorPrimarySmtpReverseOrder.count - 1 - $GrantorPrimarySmtpReverseOrder.IndexOf($GrantorPrimarySmtp))]) {
             if ($DatasetObject.Change -eq 'Deleted') {
-                Write-Host ("    Deleted: $($DatasetObject.'Trustee Primary SMTP') no longer has the '$($DatasetObject.'Permission')' right" + $(if ($DatasetObject.'Folder') { " on folder '$($DatasetObject.'Folder')'" }))
+                Write-Host ("    Deleted: '$($DatasetObject.'Trustee Original Identity')' (E-Mail '$($DatasetObject.'Trustee Primary SMTP')') no longer has the '$($DatasetObject.'Permission')' right" + $(if ($DatasetObject.'Folder') { " on folder '$($DatasetObject.'Folder')'" }))
             } elseif ($DatasetObject.change -eq 'New') {
-                Write-Host ("    New: $($DatasetObject.'Trustee Primary SMTP') now has the '$($DatasetObject.'Permission')' right" + $(if ($DatasetObject.'Folder') { " on folder '$($DatasetObject.'Folder')'" }))
+                Write-Host ("    New: '$($DatasetObject.'Trustee Original Identity')' (E-Mail '$($DatasetObject.'Trustee Primary SMTP')) now has the '$($DatasetObject.'Permission')' right" + $(if ($DatasetObject.'Folder') { " on folder '$($DatasetObject.'Folder')'" }))
             } else {
-                Write-Host ("    Unchanged: $($DatasetObject.'Trustee Primary SMTP') still has the '$($DatasetObject.'Permission')' right" + $(if ($DatasetObject.'Folder') { " on folder '$($DatasetObject.'Folder')'" }))
+                Write-Host ("    Unchanged: '$($DatasetObject.'Trustee Original Identity')' (E-Mail '$($DatasetObject.'Trustee Primary SMTP')') still has the '$($DatasetObject.'Permission')' right" + $(if ($DatasetObject.'Folder') { " on folder '$($DatasetObject.'Folder')'" }))
             }
         }
     }


### PR DESCRIPTION
## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v2.3.1" target="_blank">v2.3.1</a> - 2022-11-28
### Added
- New FAQ in '`README`': 'How to export permissions for specific public folders?'
### Fixed
- Sample code '`compare.ps1`' now additionally outputs the original identity of a trustee and not only the primary SMTP address. This helps with permissions granted to 'Anonymous' and 'Default', as well as with recipients which have been deleted in the time between the old and the new export.
- Always include trustee groups in '`GrantorFilter`' when '`ExportDistributionGroups`' is set to '`OnlyTrustees`'