### PR TITLE
v3.0.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,8 +16,9 @@
 -->
 
 
-## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/vX.X.X" target="_blank">vX.X.X</a> - YYYY-MM-DD
+## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v3.0.2" target="_blank">v3.0.2</a> - 2023-02-28
 ### Fixed
+- ExportResourceDelegates was triggered by the ExportAcceptMessagesOnlyFrom parameter, not by ExportResourceDelegates
 - ExpandGroups did not work because of assuming a wrong datatype which does not support the StartsWith method
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,11 @@
 -->
 
 
+## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/vX.X.X" target="_blank">vX.X.X</a> - YYYY-MM-DD
+### Fixed
+- ExpandGroups did not work because of assuming a wrong datatype which does not support the StartsWith method
+
+
 ## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v3.0.1" target="_blank">v3.0.1</a> - 2023-01-24
 ### Fixed
 - Direct group members were only exported as GUIDs

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -3458,7 +3458,7 @@ try {
                                 $null = Start-Transcript -LiteralPath $DebugFile -Force
                             }
 
-                            Write-Host "Import direct group membership @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
+                            Write-Host "Import security principals @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
 
                             . ([scriptblock]::Create($ConnectExchange))
 
@@ -3783,7 +3783,7 @@ try {
                                     @(
                                         (
                                             $(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz'),
-                                            'Import Recipients',
+                                            'Import direct group membership',
                                             '',
                                             $($_ | Out-String)
                                         ) | ForEach-Object { $_ -replace '"', '""' }) -join '";"'

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -7830,7 +7830,7 @@ try {
     # Get and export ResourceDelegates
     Write-Host
     Write-Host "Get and export ResourceDelegates @$(Get-Date -Format 'yyyy-MM-ddTHH:mm:sszzz')@"
-    if ($ExportAcceptMessagesOnlyFrom) {
+    if ($ExportResourceDelegates) {
         $tempQueue = [System.Collections.Queue]::Synchronized([System.Collections.Queue]::new($AllRecipients.count))
 
         foreach ($x in (0..($AllRecipients.count - 1))) {

--- a/src/Export-RecipientPermissions.ps1
+++ b/src/Export-RecipientPermissions.ps1
@@ -9538,7 +9538,7 @@ try {
                                                 foreach ($Member in $Members) {
                                                     $ExportFileLineExpanded = $ExportFileLineOriginal.PSObject.Copy()
 
-                                                    if ($Member.startswith('NotARecipient:', 'CurrentCultureIgnoreCase')) {
+                                                    if ($Member.ToString().startswith('NotARecipient:', 'CurrentCultureIgnoreCase')) {
                                                         $Trustee = $Member -replace '^NotARecipient:', ''
                                                     } else {
                                                         $Trustee = $AllRecipients[$Member]


### PR DESCRIPTION
## <a href="https://github.com/GruberMarkus/Export-RecipientPermissions/releases/tag/v3.0.2" target="_blank">v3.0.2</a> - 2023-02-28
### Fixed
- ExportResourceDelegates was triggered by the ExportAcceptMessagesOnlyFrom parameter, not by ExportResourceDelegates
- ExpandGroups did not work because of assuming a wrong datatype which does not support the StartsWith method